### PR TITLE
RFC: Binary-to-Ternary Encoding

### DIFF
--- a/text/0000-binary-to-ternary-encoding/0000-binary-to-ternary-encoding.md
+++ b/text/0000-binary-to-ternary-encoding/0000-binary-to-ternary-encoding.md
@@ -1,56 +1,78 @@
-+ Feature name: (fill me in with a unique ident, `my_awesome_feature`)
-+ Start date: (fill me in with today's date, YYYY-MM-DD)
++ Feature name: `binary-to-ternary-encoding`
++ Start date: 2020-06-08
 + RFC PR: [iotaledger/protocol-rfcs#0000](https://github.com/iotaledger/protocol-rfcs/pull/0000)
-+ (Optional) Node software implementation issues: 
-+  - [iotaledger/iri#0000](https://github.com/iotaledger/iri/issues/0000)
-+  - [iotaledger/bee#0000](https://github.com/iotaledger/bee/issues/0000)
 
 # Summary
 
-One paragraph explanation of the feature.
+In the IOTA protocol, a transaction is represented as ternary data. However, sometimes it is necessary to store binary data (e.g. the digest of a binary hash function) inside of a transaction. This requires the conversion of binary into ternary strings.
+The IOTA client libraries support the opposite conversion that encodes 5 trits as 1 byte (sometimes also referred to as `t5b1`), which is used for network communication and in storage layers. This RFC describes the corresponding counterpart to encode 1 byte as 6 trits.
 
 # Motivation
 
-Why are we doing this? What use cases does it support? What is the expected
-outcome?
-
-1. Write a summary of the motivation.
-2. List all the specific use cases that your proposal is trying to address. 
-3. Where applicable, write from the perspective of the person who will be using
-   the software, for example using the "Job story" format:
-
-When ＿＿＿ , I want to ＿＿＿, so I can ＿＿＿.
-
-+ **Example 1:** When I query a node for a list of transactions, I want to be
-  able to sort them by date, so I can work with the most relevant ones.
-+ **Example 2:** When I configure a node, I want to be able to control how much
-  transaction history the node stores, so I can make sure I only store the data
-  I need without incurring additional operational costs.
+A byte is composed of 8 bits that can represent 2<sup>8</sup> = 256 different values. On the other hand, 6 trits can hold 3<sup>6</sup> = 729 values while 5 trits can hold 3<sup>5</sup> = 243 values. Therefore, the most memory-efficient way to encode one byte requires the use of 6 trits. Although there exist many potential encoding schemes to convert binary data into ternary, the proposed version has been designed to directly match the widely used `t5b1` encoding.
 
 # Detailed design
 
-This is the bulk of the RFC. Explain the design in enough detail for somebody
-familiar with the IOTA and to understand, and for somebody familiar with Rust
-to implement. This should get into specifics and corner-cases, and include
-examples of how the feature is used.
+### Bytes to trits
+In order to encode a binary string S into ternary, each byte of S is interpreted as a signed (two's complement) 8-bit integer value v. Then, v is encoded as a little-endian 6-trit string in balanced ternary representation. Finally, the resulting groups of trits are concatenated.
+
+This algorithm can also be described using the following pseudocode:
+```
+T ← []
+foreach byte b in S:
+  v ← int(b)
+  g ← IntToTrits(v, 6)
+  T ← T || g
+```
+
+Here, the function `IntToTrits` converts a signed integer value into its corresponding balanced ternary representation in little-endian order of the given length. The functionality of `IntToTrits` exactly matches the one used to e.g. encode the transaction values as trits in the current IOTA protocol.
+
+### Trits to bytes
+
+Given a trit string T as the result of the previous encoding, T is converted back to its original byte string S by simply reversing the conversion:
+```
+S ← []
+foreach 6-trit group g in T:
+  v ← TritsToInt(g)
+  b ← byte(v)
+  T ← S || b
+```
+
+## Examples
+
+- I
+  - binary (hex): `00`
+  - ternary (trytes): `99`
+- II
+  - binary (hex): `0001020304fbfcfdfeff`
+  - ternary (trytes):
+`99A9B9C9D9V9W9X9Y9Z9`
+- III
+  - binary (hex): `9ba06c78552776a596dfe360cc2b5bf644c0f9d343a10e2e71debecd30730d03`
+  - ternary (trytes): `GWLW9DLDDCLAJDQXBWUZYZODBYPBJCQ9NCQYT9IYMBMWNASBEDTZOYCYUBGDM9C9`
 
 # Drawbacks
 
-Why should we *not* do this?
+Conceptually, one byte can be encoded using log<sub>3</sub>(256) ≈ 5.0474 trits. Thus, encoding 1 byte as 6 trits consumes considerably more memory than the mathematical minimum.
 
 # Rationale and alternatives
 
-- Why is this design the best in the space of possible designs?
-- What other designs have been considered and what is the rationale for not
-  choosing them?
-- What is the impact of not doing this?
+There are several ways to convert binary data into ternaray, e.g.
+ - the conversion used as part of the [Kerl](https://github.com/iotaledger/kerl/blob/master/IOTA-Kerl-spec.md) hash function encoding chunks of 48 bytes as 242 trits,
+ - or by encoding each bit as one trit with the corresponding value.
 
-# Unresolved questions
+Each conversion method has different advantages and disadvantages. However, since the `t5b1` encoding is well-defined and has been used in [IRI](https://github.com/iotaledger/iri) for both network communications and storage layers for a long time, choosing the direct counterpart for the opposite conversion represents the most logical solution providing a nice balance between performance and memory-efficiency.
 
-- What parts of the design do you expect to resolve through the RFC process
-  before this gets merged?
-- What parts of the design do you expect to resolve through the implementation
-  of this feature before stabilization?
-- What related issues do you consider out of scope for this RFC that could be
-  addressed in the future independently of the solution that comes out of this
-  RFC?
+# Open questions
+
+The current client libraries do not offer any functionality to convert bytes into trits. The closest offered functionality is the ASCII to trit conversion, which is used for human-readable messages in transactions:
+```
+T ← []
+foreach char c in S:
+  first ← uint8(c) mod 27
+  second ← (uint8(c)-first) / 27
+  T ← T || IntToTrits(first, 3) || IntToTrits(second, 3)
+```
+This function can be adapted to encode any general byte string. However, the conversion seems rather arbitrary and the algorithm is computationally more intense than the proposed solution.
+
+On the other hand, using the algorithm from this RFC also for the conversion of ASCII messages would break backward compatibility.

--- a/text/0000-binary-to-ternary-encoding/0000-binary-to-ternary-encoding.md
+++ b/text/0000-binary-to-ternary-encoding/0000-binary-to-ternary-encoding.md
@@ -1,0 +1,56 @@
++ Feature name: (fill me in with a unique ident, `my_awesome_feature`)
++ Start date: (fill me in with today's date, YYYY-MM-DD)
++ RFC PR: [iotaledger/protocol-rfcs#0000](https://github.com/iotaledger/protocol-rfcs/pull/0000)
++ (Optional) Node software implementation issues: 
++  - [iotaledger/iri#0000](https://github.com/iotaledger/iri/issues/0000)
++  - [iotaledger/bee#0000](https://github.com/iotaledger/bee/issues/0000)
+
+# Summary
+
+One paragraph explanation of the feature.
+
+# Motivation
+
+Why are we doing this? What use cases does it support? What is the expected
+outcome?
+
+1. Write a summary of the motivation.
+2. List all the specific use cases that your proposal is trying to address. 
+3. Where applicable, write from the perspective of the person who will be using
+   the software, for example using the "Job story" format:
+
+When ＿＿＿ , I want to ＿＿＿, so I can ＿＿＿.
+
++ **Example 1:** When I query a node for a list of transactions, I want to be
+  able to sort them by date, so I can work with the most relevant ones.
++ **Example 2:** When I configure a node, I want to be able to control how much
+  transaction history the node stores, so I can make sure I only store the data
+  I need without incurring additional operational costs.
+
+# Detailed design
+
+This is the bulk of the RFC. Explain the design in enough detail for somebody
+familiar with the IOTA and to understand, and for somebody familiar with Rust
+to implement. This should get into specifics and corner-cases, and include
+examples of how the feature is used.
+
+# Drawbacks
+
+Why should we *not* do this?
+
+# Rationale and alternatives
+
+- Why is this design the best in the space of possible designs?
+- What other designs have been considered and what is the rationale for not
+  choosing them?
+- What is the impact of not doing this?
+
+# Unresolved questions
+
+- What parts of the design do you expect to resolve through the RFC process
+  before this gets merged?
+- What parts of the design do you expect to resolve through the implementation
+  of this feature before stabilization?
+- What related issues do you consider out of scope for this RFC that could be
+  addressed in the future independently of the solution that comes out of this
+  RFC?

--- a/text/0015-binary-to-ternary-encoding/0015-binary-to-ternary-encoding.md
+++ b/text/0015-binary-to-ternary-encoding/0015-binary-to-ternary-encoding.md
@@ -53,7 +53,8 @@ foreach 6-trit group g in T:
 
 # Drawbacks
 
-Conceptually, one byte can be encoded using log<sub>3</sub>(256) ≈ 5.0474 trits. Thus, encoding 1 byte as 6 trits consumes considerably more memory than the mathematical minimum.
+- Conceptually, one byte can be encoded using log<sub>3</sub>(256) ≈ 5.0474 trits. Thus, encoding 1 byte as 6 trits consumes considerably more memory than the mathematical minimum.
+- Depending on the actual implementation the conversion might be malleable: E.g. both `Z9` (-1) and `LI`(255) could be decoded as `ff`. However, `LI` can never be the result of a valid encoding. As such, the implementation must reject such invalid inputs.
 
 # Rationale and alternatives
 

--- a/text/0015-binary-to-ternary-encoding/0015-binary-to-ternary-encoding.md
+++ b/text/0015-binary-to-ternary-encoding/0015-binary-to-ternary-encoding.md
@@ -64,11 +64,7 @@ There are several ways to convert binary data into ternary, e.g.
  - the conversion used as part of the [Kerl](https://github.com/iotaledger/kerl/blob/master/IOTA-Kerl-spec.md) hash function encoding chunks of 48 bytes as 242 trits,
  - or by encoding each bit as one trit with the corresponding value.
 
-Each conversion method has different advantages and disadvantages. However, since the `t5b1` encoding is well-defined and has been used in [IRI](https://github.com/iotaledger/iri) for both network communications and storage layers for a long time, choosing the direct counterpart for the opposite conversion represents the most logical solution providing a nice balance between performance and memory-efficiency.
-
-# Open questions
-
-The current client libraries do not offer any functionality to convert bytes into trits. The closest offered functionality is the ASCII to trit conversion, which is used for human-readable messages in transactions:
+The current client libraries do not provide any functionality to convert an arbitrary amount of bytes into trits. The closest available functionality is the ASCII to trit conversion, which is used for human-readable messages in transactions:
 ```
 T ← []
 foreach char c in S:
@@ -77,5 +73,6 @@ foreach char c in S:
   T ← T || IntToTrits(first, 3) || IntToTrits(second, 3)
 ```
 This function can be adapted to encode any general byte string. However, the conversion seems rather arbitrary and the algorithm is computationally more intense than the proposed solution.
+On the other hand, using the algorithm from this RFC also for the conversion of ASCII messages would break backward compatibility, which is also undesirable.
 
-On the other hand, using the algorithm from this RFC also for the conversion of ASCII messages would break backward compatibility.
+Each conversion method has different advantages and disadvantages. However, since the `t5b1` encoding is well-defined and has been used in [IRI](https://github.com/iotaledger/iri) for both network communications and storage layers for a long time, choosing the direct counterpart for the opposite conversion represents the most logical solution providing a nice balance between performance and memory-efficiency.

--- a/text/0015-binary-to-ternary-encoding/0015-binary-to-ternary-encoding.md
+++ b/text/0015-binary-to-ternary-encoding/0015-binary-to-ternary-encoding.md
@@ -58,7 +58,7 @@ foreach 6-trit group g in T:
 
 # Rationale and alternatives
 
-There are several ways to convert binary data into ternaray, e.g.
+There are several ways to convert binary data into ternary, e.g.
  - the conversion used as part of the [Kerl](https://github.com/iotaledger/kerl/blob/master/IOTA-Kerl-spec.md) hash function encoding chunks of 48 bytes as 242 trits,
  - or by encoding each bit as one trit with the corresponding value.
 

--- a/text/0015-binary-to-ternary-encoding/0015-binary-to-ternary-encoding.md
+++ b/text/0015-binary-to-ternary-encoding/0015-binary-to-ternary-encoding.md
@@ -20,7 +20,7 @@ This algorithm can also be described using the following pseudocode:
 ```
 T ← []
 foreach byte b in S:
-  v ← int(b)
+  v ← int8(b)
   g ← IntToTrits(v, 6)
   T ← T || g
 ```
@@ -35,7 +35,7 @@ S ← []
 foreach 6-trit group g in T:
   v ← TritsToInt(g)
   b ← byte(v)
-  T ← S || b
+  S ← S || b
 ```
 
 ## Examples
@@ -44,9 +44,9 @@ foreach 6-trit group g in T:
   - binary (hex): `00`
   - ternary (trytes): `99`
 - II
-  - binary (hex): `0001020304fbfcfdfeff`
+  - binary (hex): `0001027e7f8081fdfeff`
   - ternary (trytes):
-`99A9B9C9D9V9W9X9Y9Z9`
+`99A9B9RESEGVHVX9Y9Z9`
 - III
   - binary (hex): `9ba06c78552776a596dfe360cc2b5bf644c0f9d343a10e2e71debecd30730d03`
   - ternary (trytes): `GWLW9DLDDCLAJDQXBWUZYZODBYPBJCQ9NCQYT9IYMBMWNASBEDTZOYCYUBGDM9C9`

--- a/text/0015-binary-to-ternary-encoding/0015-binary-to-ternary-encoding.md
+++ b/text/0015-binary-to-ternary-encoding/0015-binary-to-ternary-encoding.md
@@ -5,11 +5,13 @@
 # Summary
 
 In the IOTA protocol, a transaction is represented as ternary data. However, sometimes it is necessary to store binary data (e.g. the digest of a binary hash function) inside of a transaction. This requires the conversion of binary into ternary strings.
-The IOTA client libraries support the opposite conversion that encodes 5 trits as 1 byte (sometimes also referred to as `t5b1`), which is used for network communication and in storage layers. This RFC describes the corresponding counterpart to encode 1 byte as 6 trits.
+The IOTA client libraries support the opposite conversion that encodes 5 trits as 1 byte (sometimes also referred to as `t5b1` encoding), which is used for network communication and in storage layers. This RFC describes the corresponding counterpart to encode 1 byte as 6 trits.
 
 # Motivation
 
 A byte is composed of 8 bits that can represent 2<sup>8</sup> = 256 different values. On the other hand, 6 trits can hold 3<sup>6</sup> = 729 values while 5 trits can hold 3<sup>5</sup> = 243 values. Therefore, the most memory-efficient way to encode one byte requires the use of 6 trits. Although there exist many potential encoding schemes to convert binary data into ternary, the proposed version has been designed to directly match the widely used `t5b1` encoding.
+
+It is important to note that the `b1t6` encoding presented in this RFC does not replace the current `t5b1` encoding (or its corresponding decoding): `t5b1` is for example used to store trytes in a binary database, while `b1t6` will be used to attach binary data to an IOTA transaction.
 
 # Detailed design
 
@@ -54,7 +56,7 @@ foreach 6-trit group g in T:
 # Drawbacks
 
 - Conceptually, one byte can be encoded using log<sub>3</sub>(256) ≈ 5.0474 trits. Thus, encoding 1 byte as 6 trits consumes considerably more memory than the mathematical minimum.
-- Depending on the actual implementation the conversion might be malleable: E.g. both `Z9` (-1) and `LI`(255) could be decoded as `ff`. However, `LI` can never be the result of a valid encoding. As such, the implementation must reject such invalid inputs.
+- Depending on the actual implementation the conversion might be malleable: E.g. since `byte(-1) = 0xff` and `byte(255) = 0xff`, both `Z9` (-1) and `LI`(255) could be decoded as `ff`. However, `LI` can never be the result of a valid `b1t6` encoding. As such, the implementation must reject such invalid inputs.
 
 # Rationale and alternatives
 

--- a/text/0015-binary-to-ternary-encoding/0015-binary-to-ternary-encoding.md
+++ b/text/0015-binary-to-ternary-encoding/0015-binary-to-ternary-encoding.md
@@ -1,6 +1,6 @@
 + Feature name: `binary-to-ternary-encoding`
 + Start date: 2020-06-08
-+ RFC PR: [iotaledger/protocol-rfcs#0000](https://github.com/iotaledger/protocol-rfcs/pull/0000)
++ RFC PR: [iotaledger/protocol-rfcs#0015](https://github.com/iotaledger/protocol-rfcs/pull/15)
 
 # Summary
 


### PR DESCRIPTION
[Rendered](https://github.com/Wollac/protocol-rfcs/blob/binary-to-ternary/text/0015-binary-to-ternary-encoding/0015-binary-to-ternary-encoding.md)

Example Go implementation in [wollac/iota-crypto-demo](https://github.com/Wollac/iota-crypto-demo):
- Binary-to-Ternary Encoding: [pkg/encoding/ternary/ternary.go](https://github.com/Wollac/iota-crypto-demo/blob/master/pkg/encoding/ternary/ternary.go)