### PR TITLE
Fix order of the purple set

### DIFF
--- a/text/0005-white-flag/0005-white-flag.md
+++ b/text/0005-white-flag/0005-white-flag.md
@@ -131,7 +131,7 @@ The set of blue bundles `{Q, U, X, Y, Z, W, T, P}` is confirmed by another miles
 ![][Tangle]
 
 Applying the previously shown algorithm on the purple set produces the topological order
-`{D, G, J, L, M, R, I, K, N O, S, V}`.
+`{D, G, J, L, M, R, I, K, O, N, S, V}`.
 
 ![][Tangle-conflict]
 


### PR DESCRIPTION
The RFC describes an ordering algorithm based on depth-first search, where you travel down the trunk of a milestone first, then down the branch.

I tried the example, and I think maybe O and N were the wrong way round.

So you would:

- Apply I
- Go back to O
- Apply K
- Apply O
- Go back to S
- Apply N
- Apply S
- Apply V