### PR TITLE
PoW: swap steps, to have zero trits at the end.

### DIFF
--- a/meeting-minutes/2020-08-18.md
+++ b/meeting-minutes/2020-08-18.md
@@ -44,8 +44,8 @@
 - Solution:
     - Compute the Blake2b-256 hash of the message *excluding* the last 8-byte for `nonce`
     - Convert to 192-trit string using the `b1t6` encoding.
+    - Take the 8-byte little endian encoded `nonce`, convert it into 48 trits using `b1t6`, append.
     - Append 0,0,0 to reach trits
-    - Take the 8-byte little endian encoded `nonce`, convert it into 48 trits using `b1t6`, append
     - Compute the Curl-P-81 hash of those 243-trits (always exactly one block)
     - Count the trailing zeros 
     - PoW = 3<sup>#zeros</sup> / len(message)


### PR DESCRIPTION
That's how it got implemented in https://github.com/iotaledger/iota.go/commit/a8ebed5f1a859326b89b8cac1faa5269af7e967a